### PR TITLE
I2c address fixes

### DIFF
--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -114,9 +114,9 @@ void setup() {
   #endif
   
   #ifdef V125
-  Wire1.begin(I2C_MASTER, 0x80, I2C_PINS_29_30, I2C_PULLUP_EXT, 400000);
+  Wire1.begin(I2C_MASTER, 0x34, I2C_PINS_29_30, I2C_PULLUP_EXT, 400000);
   #else
-  Wire.begin(I2C_MASTER, 0x80, I2C_PINS_18_19, I2C_PULLUP_EXT, 400000); 
+  Wire.begin(I2C_MASTER, 0x34, I2C_PINS_18_19, I2C_PULLUP_EXT, 400000); 
   #endif
 
   #else
@@ -127,11 +127,11 @@ void setup() {
   #endif
 
   #ifdef V125
-  Wire1.begin(I2C_SLAVE, 0x80, I2C_PINS_29_30, I2C_PULLUP_EXT, 400000);
+  Wire1.begin(I2C_SLAVE, 0x34, I2C_PINS_29_30, I2C_PULLUP_EXT, 400000);
   Wire1.onReceive(i2cWrite);  
   Wire1.onRequest(i2cReadRequest);
   #else
-  Wire.begin(I2C_SLAVE, 0x80, I2C_PINS_18_19, I2C_PULLUP_EXT, 400000); 
+  Wire.begin(I2C_SLAVE, 0x34, I2C_PINS_18_19, I2C_PULLUP_EXT, 400000); 
   Wire.onReceive(i2cWrite);  
   Wire.onRequest(i2cReadRequest);
   #endif

--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -237,7 +237,7 @@ void writeMidi(){
       sendi2c(0x60, device, 0x11, port, notShiftyTemp);
 
       // ER-301
-      sendi2c(0xB0, 0, 0x11, q, notShiftyTemp);
+      sendi2c(0x31, 0, 0x11, q, notShiftyTemp);
 
       // ANSIBLE
       sendi2c(0xA0, device << 1, 0x06, port, notShiftyTemp);


### PR DESCRIPTION
@bpcmusic, @Elberstein - this release corrects the address of the faderbank _and_ of the ER-301 in various I2C modes.

Let me know if you think that's right. If so, I'll close the related issues (#12, #13) and issue a new release.