### PR TITLE
Flag to flip faders top/bottom.

### DIFF
--- a/firmware/_16n_faderbank_firmware/README.md
+++ b/firmware/_16n_faderbank_firmware/README.md
@@ -19,16 +19,16 @@ Written for Teensy 3.2.
 Most configuration you'll want to do is handled in `config.h`, through a set of `define` statements.
 
 ```C
-#define DEV 1
-```
-
-will restrict everything to a single channel. Designed for breadboard development.
-
-```C
 #define REV 1
 ```
 
-will reverse the order of the analogue ports.
+will reverse the order of the faders in MIDI and I2C, right-to-left
+
+```C
+#define FLIP 1
+```
+
+will invert the direction of the faders, top-to-bottom, for MIDI and I2C. Combined with `REV`, this will allow you to use the faderbank upside down - useful if your sole connection is I2C.
 
 ```C
 #define DEBUG 1
@@ -37,12 +37,18 @@ will reverse the order of the analogue ports.
 will log debug messages to the serial port.
 
 ```C
+#define DEV 1
+```
+
+will restrict the faderbank to its first channel. Designed for breadboard development; almost certainly not of interest.
+
+```C
 #define MASTER 1
 ```
 
 will put the 16n into I2C MASTER mode, broadcasting values from the 16n directly.
 
-MASTER MODE supports up to 4 TXo modules and/or up to 4 Ansible devices and/or 1 ER-301. 
+MASTER MODE supports up to 4 TXo modules and/or up to 4 Ansible devices and/or 1 ER-301.
 
 If you want to use 16n with an ER-301, you need to turn MASTER MODE on. If you want to use it with a Monome Teletype, leave you want MASTER MODE off - leave it commented out.
 
@@ -50,7 +56,7 @@ If you want to use 16n with an ER-301, you need to turn MASTER MODE on. If you w
 
 `config.h` also contains the MIDI configuration.
 
-Midi Continuous Controller numbers are specified by the `usb_ccs` and `trs_ccs` variables; each array has sixteen items, for the faders, left to right. You can alter these should you want specific CCs to come out of the faderbank (if, for instance, you have a tool with fixed mapping, or want to directly control a piece of hardware). It is possible to set the USB MIDI port and the TRS MIDI port to output on different CCs if you wish. 
+Midi Continuous Controller numbers are specified by the `usb_ccs` and `trs_ccs` variables; each array has sixteen items, for the faders, left to right. You can alter these should you want specific CCs to come out of the faderbank (if, for instance, you have a tool with fixed mapping, or want to directly control a piece of hardware). It is possible to set the USB MIDI port and the TRS MIDI port to output on different CCs if you wish.
 
 Channels are set per-fader in `usb_channels` and `trs_channels`; again, you can have a different channel per fader if you'd like, and different channels for USB and TRS.
 

--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -172,6 +172,11 @@ void loop() {
     // read from the smoother, constrain (to account for tolerances), and map it
     temp = analog[i]->getValue();
     temp = constrain(temp, MINFADER, MAXFADER);
+
+    #ifdef FLIP
+    temp = map(temp, MINFADER, MAXFADER, MAXFADER, MINFADER);
+    #endif
+
     temp = map(temp, MINFADER, MAXFADER, 0, 16383);
    
     

--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -171,11 +171,12 @@ void loop() {
 
     // read from the smoother, constrain (to account for tolerances), and map it
     temp = analog[i]->getValue();
-    temp = constrain(temp, MINFADER, MAXFADER);
 
     #ifdef FLIP
-    temp = map(temp, MINFADER, MAXFADER, MAXFADER, MINFADER);
+    temp = MAXFADER - temp;
     #endif
+
+    temp = constrain(temp, MINFADER, MAXFADER);
 
     temp = map(temp, MINFADER, MAXFADER, 0, 16383);
    

--- a/firmware/_16n_faderbank_firmware/config.h
+++ b/firmware/_16n_faderbank_firmware/config.h
@@ -10,6 +10,9 @@
 // reverses faders left-to-right
 // #define REV 1
 
+// flips faders up-down. You almost certainly want #REV enabled as well for this.
+// #define FLIP 1
+
 // activates printing of debug messages
 // #define DEBUG 1
 


### PR DESCRIPTION
enabling the flag `FLIP` in `config.h` will flip faders to-to-bottom. This enables you to rotate the faderbank through 90º and still have it address faders left-to-right for (eg) I2C.

If you enable `FLIP`, you almost certainly want to enable `REV` too, so the faders still work bottom-to-top.