### PR TITLE
Simplify MIDI interrupts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Once upon a time, Sean Hellfritsch and Brian Crabtree [made a faderbank][linespo
 
 **16n** is the revised version of that object: it is open-source and ready for you to make, modify, or hack.
 
-It is currently at version **1.31**.
+It is currently at version **1.33**.
 
 # Repository contents
 

--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -372,24 +372,18 @@ void i2cReadRequest()
   Serial.print("i2c Read\n");
 #endif
 
-  // disable interrupts. get and cast the value
+  // get and cast the value
   uint16_t shiftReady = 0;
   switch (activeMode)
   {
   case 1:
-    noInterrupts();
     shiftReady = (uint16_t)currentValue[activeInput];
-    interrupts();
     break;
   case 2:
-    noInterrupts();
     shiftReady = (uint16_t)currentValue[activeInput];
-    interrupts();
     break;
   default:
-    noInterrupts();
     shiftReady = (uint16_t)currentValue[activeInput];
-    interrupts();
     break;
   }
 


### PR DESCRIPTION
Interrupts to call MIDI functions were doing a lot of work, especially MIDI write. Rather than doing the heavy lifting in the interrupt, the interrupt just sets a flag that a MIDI write or read should be done, and the main loop will do that at next possible opportunity and cancel the flag.

This seeks to resolve some issues reported by @altitude909 amongst others.