### PR TITLE
Implementation of MIDI Pass Thru

### DIFF
--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -57,6 +57,7 @@ int flip;
 int ledOn;
 int ledFlash;
 int i2cMaster;
+int midithru = 1;
 
 const int adcResolutionBits = 13; // 13 bit ADC resolution on Teensy 3.2
 int faderMin;
@@ -120,6 +121,20 @@ void setup()
   i2cMaster = EEPROM.read(3) == 1;
 
   usbMIDI.setHandleSystemExclusive(processIncomingSysex);
+  usbMIDI.setHandleRealTimeSystem(midiClock);
+if(midithru){
+  usbMIDI.setHandleNoteOff(midiNoteOff);
+  usbMIDI.setHandleNoteOn(midiNoteOn);
+  usbMIDI.setHandleAfterTouchPoly(midiAfterTouchPoly);
+  usbMIDI.setHandleControlChange(midiControlChange);
+  usbMIDI.setHandleProgramChange(midiProgramChange);
+  usbMIDI.setHandleAfterTouch(midiAfterTouch);
+  usbMIDI.setHandleTimeCodeQuarterFrame(midiTimeCodeQuarterFrame);
+  usbMIDI.setHandleSongPosition(midiSongPosition);
+  usbMIDI.setHandleSongSelect(midiSongSelect);
+  usbMIDI.setHandleTuneRequest(midiTuneRequest);
+}
+
 
   #ifdef V125
   // analog ports on the Teensy for the 1.25 board.

--- a/firmware/_16n_faderbank_firmware/midiClock.ino
+++ b/firmware/_16n_faderbank_firmware/midiClock.ino
@@ -1,0 +1,3 @@
+void midiClock(byte realtimebyte){
+  MIDI.sendRealTime(realtimebyte);
+}

--- a/firmware/_16n_faderbank_firmware/midiThru.ino
+++ b/firmware/_16n_faderbank_firmware/midiThru.ino
@@ -1,0 +1,30 @@
+void midiNoteOn(byte channel, byte note, byte velocity){
+  MIDI.sendNoteOn(note, velocity, channel);
+}
+void midiNoteOff(byte channel, byte note, byte velocity){
+  MIDI.sendNoteOff(note, velocity, channel);
+}
+void midiAfterTouchPoly(byte channel, byte note, byte velocity){
+  MIDI.sendAfterTouch(note, velocity, channel);
+}
+void midiAfterTouch(byte channel, byte pressure){
+  MIDI.sendAfterTouch(pressure, channel);
+}
+void midiControlChange(byte channel, byte control, byte value){
+  MIDI.sendControlChange(control, value, channel);  
+}
+void midiProgramChange(byte channel, byte program){
+  MIDI.sendProgramChange(program, channel);
+}
+void midiTimeCodeQuarterFrame(byte data){
+  MIDI.sendTimeCodeQuarterFrame(data);
+}
+void midiSongPosition(uint16_t beats){
+  MIDI.sendSongPosition(beats);
+}
+void midiSongSelect(byte songNumber){
+  MIDI.sendSongSelect(songNumber);
+}
+void midiTuneRequest(){
+  MIDI.sendTuneRequest();
+}


### PR DESCRIPTION
All midi messages sent to USB MIDI is transmitted to Serial MIDI.

Successsfully tested on Teensy3.2 and Teensy LC builds