### PR TITLE
Implemetation of MIDI Pass Thru

### DIFF
--- a/firmware/_16n_faderbank_firmware/README.md
+++ b/firmware/_16n_faderbank_firmware/README.md
@@ -61,7 +61,8 @@ FADERMAX and FADERMIN are 14-bit numbers; as such, they are stored in two bytes 
 | 3       | 0/1    | I2C Master/Follower                |
 | 4,5     | 0-127  | FADERMIN lsb/msb                   |
 | 6,7     | 0-127  | FADERMAX lsb/msb                   |
-| 8-15    |        | Currently vacant                   |
+| 8       | 0/1    | Soft MIDI thru (default 0)         |
+| 9-15    |        | Currently vacant                   |
 +---------+--------+------------------------------------+
 | 16-31   | 0-15   | Channel for each control (USB)     |
 | 32-47   | 0-15   | Channel for each control (TRS)     |

--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -57,7 +57,7 @@ int flip;
 int ledOn;
 int ledFlash;
 int i2cMaster;
-int midithru = 1;
+int midiThru;
 
 const int adcResolutionBits = 13; // 13 bit ADC resolution on Teensy 3.2
 int faderMin;
@@ -122,18 +122,19 @@ void setup()
 
   usbMIDI.setHandleSystemExclusive(processIncomingSysex);
   usbMIDI.setHandleRealTimeSystem(midiClock);
-if(midithru){
-  usbMIDI.setHandleNoteOff(midiNoteOff);
-  usbMIDI.setHandleNoteOn(midiNoteOn);
-  usbMIDI.setHandleAfterTouchPoly(midiAfterTouchPoly);
-  usbMIDI.setHandleControlChange(midiControlChange);
-  usbMIDI.setHandleProgramChange(midiProgramChange);
-  usbMIDI.setHandleAfterTouch(midiAfterTouch);
-  usbMIDI.setHandleTimeCodeQuarterFrame(midiTimeCodeQuarterFrame);
-  usbMIDI.setHandleSongPosition(midiSongPosition);
-  usbMIDI.setHandleSongSelect(midiSongSelect);
-  usbMIDI.setHandleTuneRequest(midiTuneRequest);
-}
+
+  if(midiThru){
+    usbMIDI.setHandleNoteOff(midiNoteOff);
+    usbMIDI.setHandleNoteOn(midiNoteOn);
+    usbMIDI.setHandleAfterTouchPoly(midiAfterTouchPoly);
+    usbMIDI.setHandleControlChange(midiControlChange);
+    usbMIDI.setHandleProgramChange(midiProgramChange);
+    usbMIDI.setHandleAfterTouch(midiAfterTouch);
+    usbMIDI.setHandleTimeCodeQuarterFrame(midiTimeCodeQuarterFrame);
+    usbMIDI.setHandleSongPosition(midiSongPosition);
+    usbMIDI.setHandleSongSelect(midiSongSelect);
+    usbMIDI.setHandleTuneRequest(midiTuneRequest);
+  }
 
 
   #ifdef V125

--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -57,6 +57,7 @@ int flip;
 int ledOn;
 int ledFlash;
 int i2cMaster;
+int midithru = 1;
 
 const int adcResolutionBits = 13; // 13 bit ADC resolution on Teensy 3.2
 int faderMin;
@@ -120,6 +121,20 @@ void setup()
   i2cMaster = EEPROM.read(3) == 1;
 
   usbMIDI.setHandleSystemExclusive(processIncomingSysex);
+  usbMIDI.setHandleRealTimeSystem(midiClock);
+if(midithru){
+  usbMIDI.setHandleNoteOff(midiNoteOff);
+  usbMIDI.setHandleNoteOn(midiNoteOn);
+  usbMIDI.setHandleAfterTouchPoly(midiAfterTouchPoly);
+  usbMIDI.setHandleControlChange(midiControlChange);
+  usbMIDI.setHandleProgramChange(midiProgramChange);
+  usbMIDI.setHandleAfterTouch(midiAfterTouch);
+  usbMIDI.setHandleTimeCodeQuarterFrame(midiTimeCodeQuarterFrame);
+  usbMIDI.setHandleSongPosition(midiSongPosition);
+  usbMIDI.setHandleSongSelect(midiSongSelect);
+  usbMIDI.setHandleTuneRequest(midiTuneRequest);
+}
+
 
   #ifdef V125
   // analog ports on the Teensy for the 1.25 board.

--- a/firmware/_16n_faderbank_firmware/configuration.ino
+++ b/firmware/_16n_faderbank_firmware/configuration.ino
@@ -31,14 +31,15 @@ void checkDefaultSettings() {
  void initializeFactorySettings() {
   // set default config flags (LED ON, LED DATA, ROTATE, etc)
   // fadermin/max are based on "works for me" for twra2. Your mileage may vary.
-  EEPROM.write(0,1); // LED ON
-  EEPROM.write(1,1); // LED DATA
-  EEPROM.write(2,0); // ROTATE
-  EEPROM.write(3,0); // I2C follower by default
+  EEPROM.write(0,1);  // LED ON
+  EEPROM.write(1,1);  // LED DATA
+  EEPROM.write(2,0);  // ROTATE
+  EEPROM.write(3,0);  // I2C follower by default
   EEPROM.write(4,15); // fadermin LSB
-  EEPROM.write(5,0); // fadermin MSB
+  EEPROM.write(5,0);  // fadermin MSB
   EEPROM.write(6,71); // fadermax LSB
   EEPROM.write(7,63); // fadermax MSB
+  EEPROM.write(8,0);  // Soft midi thru
 
   // set default USB channels
   for(int i = 0; i < channelCount; i++) {
@@ -121,6 +122,7 @@ void loadSettingsFromEEPROM() {
   ledOn = EEPROM.read(0);
   ledFlash = EEPROM.read(1);
   flip = EEPROM.read(2);
+  midiThru = EEPROM.read(8);
 
   // i2cMaster only read at startup
 

--- a/firmware/_16n_faderbank_firmware/midiClock.ino
+++ b/firmware/_16n_faderbank_firmware/midiClock.ino
@@ -1,0 +1,3 @@
+void midiClock(byte realtimebyte){
+  MIDI.sendRealTime(realtimebyte);
+}

--- a/firmware/_16n_faderbank_firmware/midiThru.ino
+++ b/firmware/_16n_faderbank_firmware/midiThru.ino
@@ -1,0 +1,30 @@
+void midiNoteOn(byte channel, byte note, byte velocity){
+  MIDI.sendNoteOn(note, velocity, channel);
+}
+void midiNoteOff(byte channel, byte note, byte velocity){
+  MIDI.sendNoteOff(note, velocity, channel);
+}
+void midiAfterTouchPoly(byte channel, byte note, byte velocity){
+  MIDI.sendAfterTouch(note, velocity, channel);
+}
+void midiAfterTouch(byte channel, byte pressure){
+  MIDI.sendAfterTouch(pressure, channel);
+}
+void midiControlChange(byte channel, byte control, byte value){
+  MIDI.sendControlChange(control, value, channel);  
+}
+void midiProgramChange(byte channel, byte program){
+  MIDI.sendProgramChange(program, channel);
+}
+void midiTimeCodeQuarterFrame(byte data){
+  MIDI.sendTimeCodeQuarterFrame(data);
+}
+void midiSongPosition(uint16_t beats){
+  MIDI.sendSongPosition(beats);
+}
+void midiSongSelect(byte songNumber){
+  MIDI.sendSongSelect(songNumber);
+}
+void midiTuneRequest(){
+  MIDI.sendTuneRequest();
+}

--- a/firmware/_16n_faderbank_firmware/sysex.ino
+++ b/firmware/_16n_faderbank_firmware/sysex.ino
@@ -133,6 +133,7 @@ void sendCurrentState() {
   //  fadermin MSB
   //  fadermax LSB
   //  fadermax MSB
+  //  Soft MIDI thru
 
   // 	16x USBccs
   // 	16x TRSccs


### PR DESCRIPTION
All midi messages sent to USB MIDI is transmitted to Serial MIDI.

Kicked off by @AtoVproject; successsfully tested on Teensy3.2 and Teensy LC builds.

TODO:

* extract to configuration variable
* set factory default in EEPROM
* update editor (elsewhere) to support toggling this.
