### PR TITLE
Delay bootup if 16n is in i2c master/leader mode.

### DIFF
--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -111,14 +111,14 @@ void setup()
 
   D(Serial.println("16n Firmware Debug Mode"));
 
-#ifdef BOOTDELAY // wait some time before continuing boot-up (default is none)
-  delay(BOOTDELAY);
-#endif
-
   checkDefaultSettings();
 
   loadSettingsFromEEPROM();
   i2cMaster = EEPROM.read(3) == 1;
+
+  if(i2cMaster) {
+    delay(BOOTDELAY);
+  }
 
   usbMIDI.setHandleSystemExclusive(processIncomingSysex);
   usbMIDI.setHandleRealTimeSystem(midiClock);

--- a/firmware/_16n_faderbank_firmware/config.h
+++ b/firmware/_16n_faderbank_firmware/config.h
@@ -32,9 +32,9 @@ const int DEVICE_ID = 0x02; // 16n, do not change, needed by editor
 // enables legacy compatibility with non-multiplexer boards
 // #define V125
 
-// define startup delay in milliseconds
-// largely only needed for "Sweet-Sixteen" type devices
-// #define BOOTDELAY 10000
+// define startup delay in milliseconds for i2c Leader devices
+// this gives follower devices time to boot up.
+#define BOOTDELAY 10000
 
 // I2C Address for Faderbank. 0x34 unless you ABSOLUTELY know what you are doing.
 #define I2C_ADDRESS 0x34


### PR DESCRIPTION
This solves some issues users with the device hardwired - and, for
instance, users of compatible devices, like "Sweet Sixteen", have had,
where the leader would boot before their connected follower devices
(like an ER-301) were ready.