### PR TITLE
Support devices with reversed fader direction

### DIFF
--- a/firmware/_16n_faderbank_firmware/README.md
+++ b/firmware/_16n_faderbank_firmware/README.md
@@ -44,6 +44,13 @@ will log debug messages to the serial port.
 
 will restrict the faderbank to its first channel. Designed for breadboard development; almost certainly not of interest.
 
+```C
+#define REVERSED_FADERS 1
+```
+
+will reverse the logical direction of travel of faders for devices that are
+built so that 0 is at the top, such as the Tesseract Sweet Sixteen.
+
 ## Memory Map
 
 Configuration is stored in the first 80 bytes of the on-board EEPROM. It looks like this:

--- a/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
+++ b/firmware/_16n_faderbank_firmware/_16n_faderbank_firmware.ino
@@ -51,6 +51,8 @@ int usbCCs[channelCount];
 int trsCCs[channelCount];
 int legacyPorts[channelCount]; // for V125 only
 int flip;
+int flipOrder;
+int reverseMinMax;
 int ledOn;
 int ledFlash;
 int i2cMaster;
@@ -136,7 +138,7 @@ void setup()
 
   #ifdef V125
   // analog ports on the Teensy for the 1.25 board.
-  if(flip) {
+  if(flipOrder) {
     int portsToAssign[] = {A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, A3, A2, A1, A0};
     for(int i=0; i < channelCount; i++) {
       legacyPorts[i] = portsToAssign[i];
@@ -322,7 +324,7 @@ void loop()
     temp = analogRead(legacyPorts[i]); // mux goes into A0
 #else
     // set mux to appropriate channel
-    if(flip) {
+    if(flipOrder) {
       mux.channel(muxMapping[channelCount - i - 1]);
     } else {
       mux.channel(muxMapping[i]);
@@ -343,7 +345,7 @@ void loop()
 
       temp = map(temp, faderMin, faderMax, 0, 16383);
 
-      if(flip) {
+      if(reverseMinMax) {
         temp = 16383-temp;
       }
 

--- a/firmware/_16n_faderbank_firmware/config.h
+++ b/firmware/_16n_faderbank_firmware/config.h
@@ -39,6 +39,10 @@ const int DEVICE_ID = 0x02; // 16n, do not change, needed by editor
 // I2C Address for Faderbank. 0x34 unless you ABSOLUTELY know what you are doing.
 #define I2C_ADDRESS 0x34
 
+// The device has physically reversed faders relative to the 16n
+// e.g. Sweet Sixteen.
+// #define REVERSED_FADERS 1
+
 #ifdef DEV
 
 const int channelCount = 1;

--- a/firmware/_16n_faderbank_firmware/configuration.ino
+++ b/firmware/_16n_faderbank_firmware/configuration.ino
@@ -126,6 +126,12 @@ void loadSettingsFromEEPROM() {
   ledOn = EEPROM.read(0);
   ledFlash = EEPROM.read(1);
   flip = EEPROM.read(2);
+  flipOrder = flip;
+#ifdef REVERSED_FADERS
+  reverseMinMax = !flip;
+#else
+  reverseMinMax = flip;
+#endif
   midiThru = EEPROM.read(8);
 
   // i2cMaster only read at startup


### PR DESCRIPTION
I realise that you don't necessarily want to support every possible device, so I won't be offended if you don't want to merge this! However, I think this is quite general and clarifies some of the intention of the code, and it might make it easier to maintain forks that add functionality.

This separates the meaning of `flip` into its two components:

- `flipOrder` - which fader is 1 and which is 16 etc.
- `reverseMinMax` - which end of the fader is which

By default, these are both the same, following the layout of the original 16n in which the fader is at its lowest voltage at the bottom.

However, in order to support the Sweet Sixteen or any other hypothetical build with reversed faders, we can define `REVERSED_FADERS`, and the normal (non-flipped) order will be with the highest voltage at the bottom. This is implemented by interpreting `reverseMinMax` as the opposite of `flip`.

Or, in tabular form:

    | variable      | 16n   | S16   |
    +---------------+---+---+---+---+
    | flip          | 0 | 1 | 0 | 1 |
    | flipOrder     | 0 | 1 | 0 | 1 |
    | reverseMinMax | 0 | 1 | 1 | 0 |

This also allows the Sweet Sixteen to be operated upside down, if desired.