### PR TITLE
14-bit CC support

### DIFF
--- a/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
+++ b/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
@@ -16,8 +16,6 @@
  * config.h is mainly for developer configuration.
  */
 
- #define DEBUG
-
 #include <CD74HC4067.h>
 #include <EEPROM.h>
 #include <i2c_t3.h>

--- a/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
+++ b/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
@@ -16,6 +16,8 @@
  * config.h is mainly for developer configuration.
  */
 
+ #define DEBUG
+
 #include <CD74HC4067.h>
 #include <EEPROM.h>
 #include <i2c_t3.h>
@@ -38,9 +40,9 @@ MIDI_CREATE_DEFAULT_INSTANCE();
 uint16_t current;
 uint8_t high7bits, low7bits;
 bool send14bitUSB, send14bitTRS;
-int lastMidiActivityAt;
+uint32_t lastMidiActivityAt;
 int midiDirty = 0;
-const int midiFlashDuration = 50;
+const uint32_t midiFlashDuration = 50;
 int ledPin = 13;
 
 // the storage of the values; current is in the main loop; last value is for midi output
@@ -67,7 +69,7 @@ int faderMin;
 int faderMax;
 
 bool shouldSendForcedControlUpdate = false;
-int sendForcedControlAt;
+uint32_t sendForcedControlAt;
 
 // variables for i2c master mode
 // memory of the last unshifted value
@@ -431,8 +433,8 @@ void doMidiWrite()
     current = currentValue[q];
     high7bits = (current >> 7) & 0x7F;
     low7bits = current & 0x7F;
-    send14bitUSB = usbCCs[q] < 32 && ((usbCCModes >> q) & 1) == 0;
-    send14bitTRS = trsCCs[q] < 32 && ((trsCCModes >> q) & 1) == 0;
+    send14bitUSB = usbCCs[q] < 32 && ((usbCCModes >> q) & 1) == 1;
+    send14bitTRS = trsCCs[q] < 32 && ((trsCCModes >> q) & 1) == 1;
 
     // if there was a change in the midi value
     if ((high7bits != lastMidiValue[q]) ||

--- a/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
+++ b/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
@@ -35,14 +35,18 @@
 MIDI_CREATE_DEFAULT_INSTANCE();
 
 // midi write helpers
-int shiftyTemp, notShiftyTemp, lastMidiActivityAt;
+uint16_t current;
+uint8_t high7bits, low7bits;
+bool send14bitUSB, send14bitTRS;
+int lastMidiActivityAt;
 int midiDirty = 0;
 const int midiFlashDuration = 50;
 int ledPin = 13;
 
 // the storage of the values; current is in the main loop; last value is for midi output
-int volatile currentValue[channelCount];
-int lastMidiValue[channelCount];
+uint16_t volatile currentValue[channelCount];
+uint8_t lastMidiValue[channelCount];
+uint8_t lastLowMidiValue[channelCount];
 
 // variables to hold configuration
 int usbChannels[channelCount];
@@ -64,24 +68,24 @@ bool shouldSendForcedControlUpdate = false;
 int sendForcedControlAt;
 
 // variables for i2c master mode
-  // memory of the last unshifted value
-  int lastValue[channelCount];
+// memory of the last unshifted value
+uint16_t lastValue[channelCount];
 
-  // the i2c message buffer we are sending
-  uint8_t messageBuffer[4];
+// the i2c message buffer we are sending
+uint8_t messageBuffer[4];
 
-  // temporary values
-  uint16_t valueTemp;
-  uint8_t device = 0;
-  uint8_t port = 0;
+// temporary values
+uint16_t valueTemp;
+uint8_t device = 0;
+uint8_t port = 0;
 
-  // master i2c specific stuff
-  const int ansibleI2Caddress = 0x20;
-  const int er301I2Caddress = 0x31;
-  const int txoI2Caddress = 0x60;
-  bool er301Present = false;
-  bool ansiblePresent = false;
-  bool txoPresent = false;
+// master i2c specific stuff
+const int ansibleI2Caddress = 0x20;
+const int er301I2Caddress = 0x31;
+const int txoI2Caddress = 0x60;
+bool er301Present = false;
+bool ansiblePresent = false;
+bool txoPresent = false;
 
 
 // the thing that smartly smooths the input
@@ -179,6 +183,7 @@ void setup()
 
     currentValue[i] = 0;
     lastMidiValue[i] = 0;
+    lastLowMidiValue[i] = 0;
 
     if(i2cMaster) {
       lastValue[i] = 0;
@@ -421,26 +426,36 @@ void doMidiWrite()
   // "q" is a legacy holdover
   for (int q = 0; q < channelCount; q++)
   {
-    notShiftyTemp = currentValue[q];
-
-    // shift for MIDI precision (0-127)
-    shiftyTemp = notShiftyTemp >> 7;
+    current = currentValue[q];
+    high7bits = (current >> 7) & 0x7F;
+    low7bits = current & 0x7F;
+    send14bitUSB = usbCCs[q] < 32;
+    send14bitTRS = trsCCs[q] < 32;
 
     // if there was a change in the midi value
-    if ((shiftyTemp != lastMidiValue[q]) || forceMidiWrite)
+    if ((high7bits != lastMidiValue[q]) ||
+        ((low7bits != lastLowMidiValue[q]) && (send14bitUSB || send14bitTRS)) ||
+        forceMidiWrite)
     {
       if(ledFlash && !midiDirty) {
         lastMidiActivityAt = millis();
         midiDirty = 1;
       }
       // send the message over USB and physical MIDI
-      usbMIDI.sendControlChange(usbCCs[q], shiftyTemp, usbChannels[q]);
-      MIDI.sendControlChange(trsCCs[q], shiftyTemp, trsChannels[q]);
+      usbMIDI.sendControlChange(usbCCs[q], high7bits, usbChannels[q]);
+      if (send14bitUSB) {
+        usbMIDI.sendControlChange(usbCCs[q] + 32, low7bits, usbChannels[q]);
+      }
+      MIDI.sendControlChange(trsCCs[q], high7bits, trsChannels[q]);
+      if (send14bitTRS) {
+        MIDI.sendControlChange(trsCCs[q] + 32, low7bits, trsChannels[q]);
+      }
 
       // store the shifted value for future comparison
-      lastMidiValue[q] = shiftyTemp;
+      lastMidiValue[q] = high7bits;
+      lastLowMidiValue[q] = low7bits;
 
-      D(Serial.printf("MIDI[%d]: %d\n", q, shiftyTemp));
+      D(Serial.printf("MIDI[%d]: %d\n", q, high7bits));
     }
 
     if(i2cMaster) {
@@ -448,9 +463,9 @@ void doMidiWrite()
       // we send out to all three supported i2c slave devices
       // keeps the firmware simple :)
 
-      if (notShiftyTemp != lastValue[q])
+      if (current != lastValue[q])
       {
-        D(Serial.printf("i2c Master[%d]: %d\n", q, notShiftyTemp));
+        D(Serial.printf("i2c Master[%d]: %d\n", q, current));
 
         // for 4 output devices
         port = q % 4;
@@ -458,20 +473,20 @@ void doMidiWrite()
 
         // TXo
         if(txoPresent) {
-          sendi2c(txoI2Caddress, device, 0x11, port, notShiftyTemp);
+          sendi2c(txoI2Caddress, device, 0x11, port, current);
         }
 
         // ER-301
         if(er301Present) {
-          sendi2c(er301I2Caddress, 0, 0x11, q, notShiftyTemp);
+          sendi2c(er301I2Caddress, 0, 0x11, q, current);
         }
 
         // ANSIBLE
         if(ansiblePresent) {
-          sendi2c(0x20, device << 1, 0x06, port, notShiftyTemp);
+          sendi2c(0x20, device << 1, 0x06, port, current);
         }
 
-        lastValue[q] = notShiftyTemp;
+        lastValue[q] = current;
       }
     }
   }

--- a/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
+++ b/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
@@ -431,8 +431,8 @@ void doMidiWrite()
     current = currentValue[q];
     high7bits = (current >> 7) & 0x7F;
     low7bits = current & 0x7F;
-    send14bitUSB = usbCCs[q] < 32 && ((usbCCModes >> q) & 1) == 1;
-    send14bitTRS = trsCCs[q] < 32 && ((trsCCModes >> q) & 1) == 1;
+    send14bitUSB = usbCCs[q] < 96 && ((usbCCModes >> q) & 1) == 1;
+    send14bitTRS = trsCCs[q] < 96 && ((trsCCModes >> q) & 1) == 1;
 
     // if there was a change in the midi value
     if ((high7bits != lastMidiValue[q]) ||

--- a/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
+++ b/firmware/16n_faderbank_firmware/16n_faderbank_firmware.ino
@@ -53,6 +53,8 @@ int usbChannels[channelCount];
 int trsChannels[channelCount];
 int usbCCs[channelCount];
 int trsCCs[channelCount];
+uint16_t usbCCModes;
+uint16_t trsCCModes;
 int legacyPorts[channelCount]; // for V125 only
 int flip;
 int ledOn;
@@ -429,8 +431,8 @@ void doMidiWrite()
     current = currentValue[q];
     high7bits = (current >> 7) & 0x7F;
     low7bits = current & 0x7F;
-    send14bitUSB = usbCCs[q] < 32;
-    send14bitTRS = trsCCs[q] < 32;
+    send14bitUSB = usbCCs[q] < 32 && ((usbCCModes >> q) & 1) == 0;
+    send14bitTRS = trsCCs[q] < 32 && ((trsCCModes >> q) & 1) == 0;
 
     // if there was a change in the midi value
     if ((high7bits != lastMidiValue[q]) ||

--- a/firmware/16n_faderbank_firmware/README.md
+++ b/firmware/16n_faderbank_firmware/README.md
@@ -52,20 +52,22 @@ Addresses 0-15 are reserved for configuration flags/data.
 
 FADERMAX and FADERMIN are 14-bit numbers; as such, they are stored in two bytes as MSB and LSB; the actual number is calculated by `(MSB << 8) + LSB`
 
-| Address | Format |            Description             |
-|---------|--------|------------------------------------|
-| 0       | 0/1    | LED on when powered                |
-| 1       | 0/1    | LED blink on MIDI data             |
-| 2       | 0/1    | Rotate controller outputs via 180º |
-| 3       | 0/1    | I2C Master/Follower                |
-| 4,5     | 0-127  | FADERMIN lsb/msb                   |
-| 6,7     | 0-127  | FADERMAX lsb/msb                   |
-| 8       | 0/1    | Soft MIDI thru (default 0)         |
-| 9-15    |        | Currently unused                   |
-| 16-31   | 0-15   | Channel for each control (USB)     |
-| 32-47   | 0-15   | Channel for each control (TRS)     |
-| 48-63   | 0-127  | CC for each control (USB)          |
-| 64-79   | 0-127  | CC for each control (TRS)          |
+| Address | Format  |            Description             |
+|---------|---------|------------------------------------|
+| 0       | 0/1     | LED on when powered                |
+| 1       | 0/1     | LED blink on MIDI data             |
+| 2       | 0/1     | Rotate controller outputs via 180º |
+| 3       | 0/1     | I2C Master/Follower                |
+| 4,5     | 0-127   | FADERMIN lsb/msb                   |
+| 6,7     | 0-127   | FADERMAX lsb/msb                   |
+| 8       | 0/1     | Soft MIDI thru (default 0)         |
+| 9-15    |         | Currently unused                   |
+| 16-31   | 0-15    | Channel for each control (USB)     |
+| 32-47   | 0-15    | Channel for each control (TRS)     |
+| 48-63   | 0-127   | CC for each control (USB)          |
+| 64-79   | 0-127   | CC for each control (TRS)          |
+| 80-81   | bitmask | CC mode: 1=normal, 0=14-bit (USB)  |
+| 82-83   | bitmask | CC mode: 1=normal, 0=14-bit (TRS)  |
 
 ## LICENSING
 

--- a/firmware/16n_faderbank_firmware/README.md
+++ b/firmware/16n_faderbank_firmware/README.md
@@ -8,7 +8,7 @@ If you are interested in compiling your own firmware, or hacking on it, read on!
 
 ## Requirements
 
-- Teensyduino install (currently: Teensyduino v1.5.3 with Arduino 1.8.13)
+- Arduino + Teensyduino install (currently: [Arduino](https://www.arduino.cc/en/software) 2.3.4 with [Teensyduino](https://www.pjrc.com/teensy/td_download.html) v1.59.0)
 - `ResponsiveAnalogRead` library
 - `CD74HC4067` library
 
@@ -46,7 +46,7 @@ will restrict the faderbank to its first channel. Designed for breadboard develo
 
 ## Memory Map
 
-Configuration is stored in the first 80 bytes of the on-board EEPROM. It looks like this:
+Configuration is stored in the first 86 bytes of the on-board EEPROM. It looks like this:
 
 Addresses 0-15 are reserved for configuration flags/data.
 
@@ -66,8 +66,8 @@ FADERMAX and FADERMIN are 14-bit numbers; as such, they are stored in two bytes 
 | 32-47   | 0-15    | Channel for each control (TRS)     |
 | 48-63   | 0-127   | CC for each control (USB)          |
 | 64-79   | 0-127   | CC for each control (TRS)          |
-| 80-81   | bitmask | CC mode: 1=normal, 0=14-bit (USB)  |
-| 82-83   | bitmask | CC mode: 1=normal, 0=14-bit (TRS)  |
+| 80-82   | 0-127   | Booleans for high-res mode (USB)   |
+| 83-85   | 0-127   | Booleans for high-res mode (TRS)   |
 
 ## LICENSING
 

--- a/firmware/16n_faderbank_firmware/SYSEX_SPEC.md
+++ b/firmware/16n_faderbank_firmware/SYSEX_SPEC.md
@@ -20,11 +20,11 @@ Request for 16n to transmit current state via sysex. No other payload.
 
 ## `0x0C` - "c0nfig edit (usb options)"
 
-"Here is a new set of USB options for you". Payload (other than mfg header, top/tail, etc) of 32 bytes to go straight into appropriate locations of EEPROM, according to the memory map described in `README.md`.
+"Here is a new set of USB options for you". Payload (other than mfg header, top/tail, etc) of 34 bytes to go straight into appropriate locations of EEPROM, according to the memory map described in `README.md`.
 
 ## `0x0B` - "c0nfig edit (trs options)"
 
-"Here is a new set of TRS options for you". Payload (other than mfg header, top/tail, etc) of 32 bytes to go straight into appropriate locations of EEPROM, according to the memory map described in `README.md`.
+"Here is a new set of TRS options for you". Payload (other than mfg header, top/tail, etc) of 34 bytes to go straight into appropriate locations of EEPROM, according to the memory map described in `README.md`.
 
 ## `0x1A` - "1nitiAlize memory"
 

--- a/firmware/16n_faderbank_firmware/config.h
+++ b/firmware/16n_faderbank_firmware/config.h
@@ -51,4 +51,4 @@ const int channelCount = 16;
 #endif
 
 // size of eeprom config
-#define EEPROM_DATA_SIZE 84
+#define EEPROM_DATA_SIZE 86

--- a/firmware/16n_faderbank_firmware/config.h
+++ b/firmware/16n_faderbank_firmware/config.h
@@ -49,3 +49,6 @@ const int ports[] = {A0};
 const int channelCount = 16;
 
 #endif
+
+// size of eeprom config
+#define EEPROM_DATA_SIZE 84

--- a/firmware/16n_faderbank_firmware/config.h
+++ b/firmware/16n_faderbank_firmware/config.h
@@ -10,8 +10,8 @@
  */
 
 int MAJOR_VERSION = 0x02;
-int MINOR_VERSION = 0x01;
-int POINT_VERSION = 0x01;
+int MINOR_VERSION = 0x02;
+int POINT_VERSION = 0x00;
 
 /*
  * device metadata

--- a/firmware/16n_faderbank_firmware/configuration.ino
+++ b/firmware/16n_faderbank_firmware/configuration.ino
@@ -74,10 +74,10 @@ void checkDefaultSettings() {
   }
 
   // set default CC modes
-  for(int i = 0; i < 4; i++) {
+  for(int i = 0; i < 6; i++) {
     int baseAddress = 80;
     int writeAddress = baseAddress + i;
-    EEPROM.write(writeAddress, 0xFF);
+    EEPROM.write(writeAddress, 0x00);
   }
 
   // serial dump that config.
@@ -130,18 +130,20 @@ void loadSettingsFromEEPROM() {
   D(printIntArray(trsCCs,channelCount));
 
   // load USB CC mode flags
-  usbCCModes = (EEPROM.read(80) << 8) | EEPROM.read(81);
+  usbCCModes = (EEPROM.read(80) & 0x7F) | ((EEPROM.read(81) & 0x7F) << 7) | ((EEPROM.read(82) & 0x03) << 14);
 
   D(Serial.println("USB CC modes loaded:"));
   D(printHex(usbCCModes >> 8));
   D(printHex(usbCCModes & 0xFF));
+  D(Serial.println());
 
-  // load TRS mode flags
-  trsCCModes = (EEPROM.read(82) << 8) | EEPROM.read(83);
+  // load TRS CC mode flags
+  trsCCModes = (EEPROM.read(83) & 0x7F) | ((EEPROM.read(84) & 0x7F) << 7) | ((EEPROM.read(85) & 0x03) << 14);
 
   D(Serial.println("TRS CC modes loaded:"));
   D(printHex(trsCCModes >> 8));
   D(printHex(trsCCModes & 0xFF));
+  D(Serial.println());
 
 
   // load other config

--- a/firmware/16n_faderbank_firmware/configuration.ino
+++ b/firmware/16n_faderbank_firmware/configuration.ino
@@ -77,7 +77,7 @@ void checkDefaultSettings() {
   for(int i = 0; i < 4; i++) {
     int baseAddress = 80;
     int writeAddress = baseAddress + i;
-    EEPROM.write(writeAddress, 0x7F);
+    EEPROM.write(writeAddress, 0xFF);
   }
 
   // serial dump that config.

--- a/firmware/16n_faderbank_firmware/configuration.ino
+++ b/firmware/16n_faderbank_firmware/configuration.ino
@@ -22,9 +22,9 @@ void checkDefaultSettings() {
     D(printHex(firstByte));
     D(Serial.println());
     byte buffer[80];
-    readEEPROMArray(0, buffer, 80);
+    readEEPROMArray(0, buffer, EEPROM_DATA_SIZE);
     D(Serial.println("Config found:"));
-    D(printHexArray(buffer, 80));
+    D(printHexArray(buffer, EEPROM_DATA_SIZE));
   }
 }
 
@@ -73,11 +73,18 @@ void checkDefaultSettings() {
     EEPROM.write(writeAddress, defaultTRSCCs[i]);
   }
 
+  // set default CC modes
+  for(int i = 0; i < 4; i++) {
+    int baseAddress = 80;
+    int writeAddress = baseAddress + i;
+    EEPROM.write(writeAddress, 0x7F);
+  }
+
   // serial dump that config.
-  byte buffer[80];
-  readEEPROMArray(0,buffer,80);
+  byte buffer[EEPROM_DATA_SIZE];
+  readEEPROMArray(0,buffer,EEPROM_DATA_SIZE);
   D(Serial.println("Config Instantiated."));
-  D(printHexArray(buffer, 80));
+  D(printHexArray(buffer, EEPROM_DATA_SIZE));
 }
 
 void loadSettingsFromEEPROM() {
@@ -121,6 +128,21 @@ void loadSettingsFromEEPROM() {
 
   D(Serial.println("TRS CCs loaded:"));
   D(printIntArray(trsCCs,channelCount));
+
+  // load USB CC mode flags
+  usbCCModes = (EEPROM.read(80) << 8) | EEPROM.read(81);
+
+  D(Serial.println("USB CC modes loaded:"));
+  D(printHex(usbCCModes >> 8));
+  D(printHex(usbCCModes & 0xFF));
+
+  // load TRS mode flags
+  trsCCModes = (EEPROM.read(82) << 8) | EEPROM.read(83);
+
+  D(Serial.println("TRS CC modes loaded:"));
+  D(printHex(trsCCModes >> 8));
+  D(printHex(trsCCModes & 0xFF));
+
 
   // load other config
   ledOn = EEPROM.read(0);

--- a/firmware/16n_faderbank_firmware/midiClock.ino
+++ b/firmware/16n_faderbank_firmware/midiClock.ino
@@ -1,3 +1,3 @@
 void midiClock(byte realtimebyte){
-  MIDI.sendRealTime(realtimebyte);
+  MIDI.sendRealTime((midi::MidiType)realtimebyte);
 }

--- a/firmware/16n_faderbank_firmware/sysex.ino
+++ b/firmware/16n_faderbank_firmware/sysex.ino
@@ -86,7 +86,7 @@ void updateUSBSettingsAndStoreInEEPROM(byte* newConfig, unsigned size) {
   // store CCs
   updateSettingsBlockAndStoreInEEPROM(newConfig,size,21,16,48);
   // store 14-bit flags
-  updateSettingsBlockAndStoreInEEPROM(newConfig,size,37,2,80);
+  updateSettingsBlockAndStoreInEEPROM(newConfig,size,37,3,80);
 }
 
 void updateTRSSettingsAndStoreInEEPROM(byte* newConfig, unsigned size) {
@@ -95,7 +95,7 @@ void updateTRSSettingsAndStoreInEEPROM(byte* newConfig, unsigned size) {
   // store CCs
   updateSettingsBlockAndStoreInEEPROM(newConfig,size,21,16,64);
   // store 14-bit flags
-  updateSettingsBlockAndStoreInEEPROM(newConfig,size,37,2,82);
+  updateSettingsBlockAndStoreInEEPROM(newConfig,size,37,3,83);
 }
 
 void updateSettingsBlockAndStoreInEEPROM(byte* configFromSysex, unsigned sysexSize, int configStartIndex, int configDataLength, int EEPROMStartIndex) { 
@@ -114,7 +114,7 @@ void updateSettingsBlockAndStoreInEEPROM(byte* configFromSysex, unsigned sysexSi
   unsigned dataToWriteLength = configDataLength;
 
   for(int i = 0; i < (configDataLength); i++) {
-    int configIndex = i + configStartIndex;
+    unsigned configIndex = i + configStartIndex;
     if (configIndex >= sysexSize) {
       // the sysex message is shorter than expected, only write what we receieved
       dataToWriteLength = i;
@@ -160,10 +160,10 @@ void sendCurrentState() {
   // 	16x TRSccs
   // 	16x USBchannel
   // 	16x TRS channel
-  //  2 bytes for USB CC modes
-  //  2 bytes for TRS CC modes
+  //  3 bytes for USB CC modes
+  //  3 bytes for TRS CC modes
     
-  // So that's 3 for the mfg + 1 for the message + 80 bytes
+  // So that's 3 for the mfg + 1 for the message + 86 bytes
   // can be done with a simple "read EEPROM_DATA_SIZE bytes and send them."
 
   byte buffer[EEPROM_DATA_SIZE];

--- a/firmware/16n_faderbank_firmware/sysex.ino
+++ b/firmware/16n_faderbank_firmware/sysex.ino
@@ -160,6 +160,8 @@ void sendCurrentState() {
   // 	16x TRSccs
   // 	16x USBchannel
   // 	16x TRS channel
+  //  2 bytes for USB CC modes
+  //  2 bytes for TRS CC modes
     
   // So that's 3 for the mfg + 1 for the message + 80 bytes
   // can be done with a simple "read EEPROM_DATA_SIZE bytes and send them."

--- a/firmware/16n_faderbank_firmware/sysex.ino
+++ b/firmware/16n_faderbank_firmware/sysex.ino
@@ -162,17 +162,14 @@ void sendCurrentState() {
   // 	16x TRS channel
     
   // So that's 3 for the mfg + 1 for the message + 80 bytes
-  // can be done with a simple "read eighty bytes and send them."
+  // can be done with a simple "read EEPROM_DATA_SIZE bytes and send them."
 
   byte buffer[EEPROM_DATA_SIZE];
   readEEPROMArray(0, buffer, EEPROM_DATA_SIZE);
 
   int offset = 8;
   for(int i = 0; i < EEPROM_DATA_SIZE; i++) {
-    byte data = buffer[i];
-    if(data == 0xff) {
-      data = 0x7f;
-    }
+    byte data = buffer[i] & 0x7F;
     sysexData[i+offset] = data;
   }
 

--- a/firmware/16n_faderbank_firmware/sysex.ino
+++ b/firmware/16n_faderbank_firmware/sysex.ino
@@ -67,7 +67,7 @@ void updateAllSettingsAndStoreInEEPROM(byte* newConfig, unsigned size) {
   D(Serial.println(size));
   // D(printHexArray(newConfig,size));
 
-  updateSettingsBlockAndStoreInEEPROM(newConfig,size,9,80,0);
+  updateSettingsBlockAndStoreInEEPROM(newConfig,size,9,EEPROM_DATA_SIZE,0);
 }
 
 void updateDeviceSettingsAndStoreInEEPROM(byte* newConfig, unsigned size) {
@@ -85,6 +85,8 @@ void updateUSBSettingsAndStoreInEEPROM(byte* newConfig, unsigned size) {
   updateSettingsBlockAndStoreInEEPROM(newConfig,size,5,16,16);
   // store CCs
   updateSettingsBlockAndStoreInEEPROM(newConfig,size,21,16,48);
+  // store 14-bit flags
+  updateSettingsBlockAndStoreInEEPROM(newConfig,size,37,2,80);
 }
 
 void updateTRSSettingsAndStoreInEEPROM(byte* newConfig, unsigned size) {
@@ -92,6 +94,8 @@ void updateTRSSettingsAndStoreInEEPROM(byte* newConfig, unsigned size) {
   updateSettingsBlockAndStoreInEEPROM(newConfig,size,5,16,32);
   // store CCs
   updateSettingsBlockAndStoreInEEPROM(newConfig,size,21,16,64);
+  // store 14-bit flags
+  updateSettingsBlockAndStoreInEEPROM(newConfig,size,37,2,82);
 }
 
 void updateSettingsBlockAndStoreInEEPROM(byte* configFromSysex, unsigned sysexSize, int configStartIndex, int configDataLength, int EEPROMStartIndex) { 
@@ -107,21 +111,27 @@ void updateSettingsBlockAndStoreInEEPROM(byte* configFromSysex, unsigned sysexSi
 
   // walk the config, ignoring the top, tail, and firmware version
   byte dataToWrite[configDataLength];
+  unsigned dataToWriteLength = configDataLength;
 
   for(int i = 0; i < (configDataLength); i++) {
     int configIndex = i + configStartIndex;
+    if (configIndex >= sysexSize) {
+      // the sysex message is shorter than expected, only write what we receieved
+      dataToWriteLength = i;
+      break;
+    }
     dataToWrite[i] = configFromSysex[configIndex];
   }
 
   // write new Data
-  writeEEPROMArray(EEPROMStartIndex, dataToWrite, configDataLength);
+  writeEEPROMArray(EEPROMStartIndex, dataToWrite, dataToWriteLength);
 
   // now load that.
   loadSettingsFromEEPROM();
 }
 void sendCurrentState() {
   //   0F - "c0nFig" - outputs its config:
-  byte sysexData[88];
+  byte sysexData[EEPROM_DATA_SIZE + 8];
 
   sysexData[0] = 0x7d; // manufacturer
   sysexData[1] = 0x00;
@@ -154,11 +164,11 @@ void sendCurrentState() {
   // So that's 3 for the mfg + 1 for the message + 80 bytes
   // can be done with a simple "read eighty bytes and send them."
 
-  byte buffer[80];
-  readEEPROMArray(0, buffer, 80);
+  byte buffer[EEPROM_DATA_SIZE];
+  readEEPROMArray(0, buffer, EEPROM_DATA_SIZE);
 
   int offset = 8;
-  for(int i = 0; i < 80; i++) {
+  for(int i = 0; i < EEPROM_DATA_SIZE; i++) {
     byte data = buffer[i];
     if(data == 0xff) {
       data = 0x7f;
@@ -167,8 +177,8 @@ void sendCurrentState() {
   }
 
   D(Serial.println("Sending this data"));
-  D(printHexArray(sysexData,88));
+  D(printHexArray(sysexData, EEPROM_DATA_SIZE + 8));
 
-  usbMIDI.sendSysEx(88, sysexData, false);
+  usbMIDI.sendSysEx(EEPROM_DATA_SIZE + 8, sysexData, false);
   forceMidiWrite = true;
 }

--- a/firmware/16n_faderbank_firmware/utils.ino
+++ b/firmware/16n_faderbank_firmware/utils.ino
@@ -17,7 +17,7 @@ void writeEEPROMArray(int start, byte buffer[], int length) {
 }
 
 void printHex(uint8_t num) {
-  char hexCar[2];
+  char hexCar[3];
 
   sprintf(hexCar, "%02X", num);
   Serial.print(hexCar);


### PR DESCRIPTION
As discussed in #63.

This has been lightly tested with a Teensy 3.2 based 16n, controlling Resolume and the [unreleased 14-bit branch](https://github.com/Dewb/monome-rack/tree/feat/14bit-fb) of the monome plugin for VCV Rack. Sysex messages have been simulated with Max.

Todo:
- [x] test on teensy LC based hardware
- [x] test controlling other popular software with 14-bit support
- [x] more rigorous sysex testing
- [x] test TRS midi
- [x] ~~currently impossible to set the config bit high for faders 8 and 16 because sysex data bytes have to have the high bit low (see [comment here](https://github.com/16n-faderbank/16n/issues/63#issuecomment-2479459395).)~~

not in scope for this PR but related:
- ~~editor changes~~ (https://github.com/16n-faderbank/16n-editor/pull/27)
- ~~16nx firmware changes~~ (https://github.com/16n-faderbank/16next_firmware/pull/15)

Max 8 test patch:
[16n_14bitCC_sysex_test.zip](https://github.com/user-attachments/files/17788162/16n_14bitCC_sysex_test.zip)
